### PR TITLE
mailparse_rfc822_parse_addresses() does not parse Quotes (") correctly

### DIFF
--- a/tests/bug002.phpt
+++ b/tests/bug002.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check mailparse_rfc822_parse_addresses
+--SKIPIF--
+<?php
+/* vim600: sw=4 ts=4 fdm=marker syn=php
+*/
+if (!extension_loaded("mailparse")) @dl("mailparse.so");
+if (!extension_loaded("mailparse")) print "skip"; ?>
+--POST--
+--GET--
+--FILE--
+<?php 
+if (!extension_loaded("mailparse")) @dl("mailparse.so");
+$addresses = <<<EOD
+"Giant; \"Big\" Box" <sysservices@example.net>
+EOD;
+
+$addressesParsed = mailparse_rfc822_parse_addresses($addresses);
+
+echo $addressesParsed[0]['display'];
+?>
+--EXPECT--
+Giant; "Big" Box


### PR DESCRIPTION
Hello,


Example:

`"Alan \"Crane\" Woke"`

It should be parsed to

`Alan "Crane" Woke`

but it is being parsed to:

`Alan \ Crane\ Woke`

See RFC2822 for further information: https://www.ietf.org/rfc/rfc2822.txt (Page 41)
